### PR TITLE
chore: Bump stuff and fix the bit rot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-  
+
 name: CI
 
 on:
@@ -36,21 +36,21 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
-          
+
     - name: Install GitVersion
-      uses: gittools/actions/gitversion/setup@v0.9.10
+      uses: gittools/actions/gitversion/setup@v0.10.2
       with:
         versionSpec: '5.x'
 
     - name: Determine Version
       id:   gitversion
-      uses: gittools/actions/gitversion/execute@v0.9.10
+      uses: gittools/actions/gitversion/execute@v0.10.2
 
     - name: Setup NuGet
-      uses: NuGet/setup-nuget@v1.0.5
+      uses: NuGet/setup-nuget@v1.2.0
 
     - name: Restore dependencies
       run: nuget restore $env:SOLUTION
@@ -62,7 +62,7 @@ jobs:
       shell: pwsh
 
     - name: Setup MSBuild
-      uses: microsoft/setup-msbuild@v1.0.2
+      uses: microsoft/setup-msbuild@v1.1.3
 
     - name: Build
       run: msbuild $env:SOLUTION /p:Configuration=$env:BUILD_CONFIG /p:Platform="Any CPU" -p:Version=${{ steps.gitversion.outputs.assemblySemVer }}
@@ -78,7 +78,7 @@ jobs:
       shell: pwsh
 
     - name: Publish nuget artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: packages.${{ steps.gitversion.outputs.semVer }}
         path: .nupkgs/**

--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -1,4 +1,4 @@
-  
+
 name: CI Linux
 
 on:
@@ -32,22 +32,22 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
-          
+
     - name: Install GitVersion
-      uses: gittools/actions/gitversion/setup@v0.9.10
+      uses: gittools/actions/gitversion/setup@v0.10.2
       with:
         versionSpec: '5.x'
 
     - name: Determine Version
       id:   gitversion
-      uses: gittools/actions/gitversion/execute@v0.9.10
+      uses: gittools/actions/gitversion/execute@v0.10.2
 
-    - uses: actions/setup-dotnet@v1
+    - uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 3.1.x
-    
+        dotnet-version: 8.0.x
+
     - name: Run tests
       run: dotnet test ${{ env.SOLUTION }} /p:Configuration=${{ env.BUILD_CONFIG }} /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura -l "console;verbosity=detailed"

--- a/MemoryModule.Tests/MemoryModule.Tests.csproj
+++ b/MemoryModule.Tests/MemoryModule.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/MemoryModule/Linux/GlibcInterop/2_35/32/Natives.g.cs
+++ b/MemoryModule/Linux/GlibcInterop/2_35/32/Natives.g.cs
@@ -1,0 +1,208 @@
+// Native structure offsets for glibc, on x86 and x86_64.
+// Generated using GlibcOffsetGen. Do not modify.
+
+using System;
+using System.Runtime.InteropServices;
+namespace GlibcInterop
+{
+    [StructLayout(LayoutKind.Explicit, Size = 2348)]
+    unsafe partial struct rtld_global_2_35_32
+    {
+        [FieldOffset(0)]
+        fixed byte _dl_ns[1408];
+        [FieldOffset(1408)]
+        fixed byte _dl_nns[4];
+        [FieldOffset(1412)]
+        fixed byte _dl_load_lock[24];
+        [FieldOffset(1436)]
+        fixed byte _dl_load_write_lock[24];
+        [FieldOffset(1460)]
+        fixed byte _dl_load_tls_lock[24];
+        [FieldOffset(1484)]
+        fixed byte _dl_load_adds[8];
+        [FieldOffset(1492)]
+        fixed byte _dl_initfirst[4];
+        [FieldOffset(1496)]
+        fixed byte _dl_profile_map[4];
+        [FieldOffset(1500)]
+        fixed byte _dl_num_relocations[4];
+        [FieldOffset(1504)]
+        fixed byte _dl_num_cache_relocations[4];
+        [FieldOffset(1508)]
+        fixed byte _dl_all_dirs[4];
+        [FieldOffset(1512)]
+        fixed byte _dl_rtld_map[624];
+        [FieldOffset(2136)]
+        fixed byte _dl_rtld_auditstate[128];
+        [FieldOffset(2264)]
+        fixed byte _dl_x86_feature_1[4];
+        [FieldOffset(2268)]
+        fixed byte _dl_x86_feature_control[4];
+        [FieldOffset(2272)]
+        fixed byte _dl_stack_flags[4];
+        [FieldOffset(2276)]
+        fixed byte _dl_tls_dtv_gaps[1];
+        [FieldOffset(2280)]
+        fixed byte _dl_tls_max_dtv_idx[4];
+        [FieldOffset(2284)]
+        fixed byte _dl_tls_dtv_slotinfo_list[4];
+        [FieldOffset(2288)]
+        fixed byte _dl_tls_static_nelem[4];
+        [FieldOffset(2292)]
+        fixed byte _dl_tls_static_used[4];
+        [FieldOffset(2296)]
+        fixed byte _dl_tls_static_optional[4];
+        [FieldOffset(2300)]
+        fixed byte _dl_initial_dtv[4];
+        [FieldOffset(2304)]
+        fixed byte _dl_tls_generation[4];
+        [FieldOffset(2308)]
+        fixed byte _dl_scope_free_list[4];
+        [FieldOffset(2312)]
+        fixed byte _dl_stack_used[8];
+        [FieldOffset(2320)]
+        fixed byte _dl_stack_user[8];
+        [FieldOffset(2328)]
+        fixed byte _dl_stack_cache[8];
+        [FieldOffset(2336)]
+        fixed byte _dl_stack_cache_actsize[4];
+        [FieldOffset(2340)]
+        fixed byte _dl_in_flight_stack[4];
+        [FieldOffset(2344)]
+        fixed byte _dl_stack_cache_lock[4];
+    }
+
+    [StructLayout(LayoutKind.Explicit, Size = 624)]
+    unsafe partial struct link_map_2_35_32
+    {
+        [FieldOffset(0)]
+        fixed byte l_addr[4];
+        [FieldOffset(4)]
+        fixed byte l_name[4];
+        [FieldOffset(8)]
+        fixed byte l_ld[4];
+        [FieldOffset(12)]
+        fixed byte l_next[4];
+        [FieldOffset(16)]
+        fixed byte l_prev[4];
+        [FieldOffset(20)]
+        fixed byte l_real[4];
+        [FieldOffset(24)]
+        fixed byte l_ns[4];
+        [FieldOffset(28)]
+        fixed byte l_libname[4];
+        [FieldOffset(32)]
+        fixed byte l_info[308];
+        [FieldOffset(340)]
+        fixed byte l_phdr[4];
+        [FieldOffset(344)]
+        fixed byte l_entry[4];
+        [FieldOffset(348)]
+        fixed byte l_phnum[2];
+        [FieldOffset(350)]
+        fixed byte l_ldnum[2];
+        [FieldOffset(352)]
+        fixed byte l_searchlist[8];
+        [FieldOffset(360)]
+        fixed byte l_symbolic_searchlist[8];
+        [FieldOffset(368)]
+        fixed byte l_loader[4];
+        [FieldOffset(372)]
+        fixed byte l_versions[4];
+        [FieldOffset(376)]
+        fixed byte l_nversions[4];
+        [FieldOffset(380)]
+        fixed byte l_nbuckets[4];
+        [FieldOffset(384)]
+        fixed byte l_gnu_bitmask_idxbits[4];
+        [FieldOffset(388)]
+        fixed byte l_gnu_shift[4];
+        [FieldOffset(392)]
+        fixed byte l_gnu_bitmask[4];
+        [FieldOffset(396)]
+        fixed byte l_gnu_buckets[4];
+        [FieldOffset(396)]
+        fixed byte l_chain[4];
+        [FieldOffset(400)]
+        fixed byte l_gnu_chain_zero[4];
+        [FieldOffset(400)]
+        fixed byte l_buckets[4];
+        [FieldOffset(404)]
+        fixed byte l_direct_opencount[4];
+        [FieldOffset(411)]
+        fixed byte l_nodelete_active[1];
+        [FieldOffset(412)]
+        fixed byte l_nodelete_pending[1];
+        [FieldOffset(416)]
+        fixed byte l_x86_feature_1_and[4];
+        [FieldOffset(420)]
+        fixed byte l_x86_isa_1_needed[4];
+        [FieldOffset(424)]
+        fixed byte l_1_needed[4];
+        [FieldOffset(428)]
+        fixed byte l_rpath_dirs[8];
+        [FieldOffset(436)]
+        fixed byte l_reloc_result[4];
+        [FieldOffset(440)]
+        fixed byte l_versyms[4];
+        [FieldOffset(444)]
+        fixed byte l_origin[4];
+        [FieldOffset(448)]
+        fixed byte l_map_start[4];
+        [FieldOffset(452)]
+        fixed byte l_map_end[4];
+        [FieldOffset(456)]
+        fixed byte l_text_end[4];
+        [FieldOffset(460)]
+        fixed byte l_scope_mem[16];
+        [FieldOffset(476)]
+        fixed byte l_scope_max[4];
+        [FieldOffset(484)]
+        fixed byte l_local_scope[8];
+        [FieldOffset(492)]
+        fixed byte l_file_id[16];
+        [FieldOffset(508)]
+        fixed byte l_runpath_dirs[8];
+        [FieldOffset(520)]
+        fixed byte l_reldeps[4];
+        [FieldOffset(524)]
+        fixed byte l_reldepsmax[4];
+        [FieldOffset(528)]
+        fixed byte l_used[4];
+        [FieldOffset(532)]
+        fixed byte l_feature_1[4];
+        [FieldOffset(536)]
+        fixed byte l_flags_1[4];
+        [FieldOffset(540)]
+        fixed byte l_flags[4];
+        [FieldOffset(544)]
+        fixed byte l_idx[4];
+        [FieldOffset(548)]
+        fixed byte l_mach[12];
+        [FieldOffset(560)]
+        fixed byte l_lookup_cache[16];
+        [FieldOffset(576)]
+        fixed byte l_tls_initimage[4];
+        [FieldOffset(580)]
+        fixed byte l_tls_initimage_size[4];
+        [FieldOffset(584)]
+        fixed byte l_tls_blocksize[4];
+        [FieldOffset(588)]
+        fixed byte l_tls_align[4];
+        [FieldOffset(592)]
+        fixed byte l_tls_firstbyte_offset[4];
+        [FieldOffset(596)]
+        fixed byte l_tls_offset[4];
+        [FieldOffset(600)]
+        fixed byte l_tls_modid[4];
+        [FieldOffset(604)]
+        fixed byte l_tls_dtor_count[4];
+        [FieldOffset(608)]
+        fixed byte l_relro_addr[4];
+        [FieldOffset(612)]
+        fixed byte l_relro_size[4];
+        [FieldOffset(616)]
+        fixed byte l_serial[8];
+    }
+
+}

--- a/MemoryModule/Linux/GlibcInterop/2_35/64/Natives.g.cs
+++ b/MemoryModule/Linux/GlibcInterop/2_35/64/Natives.g.cs
@@ -1,0 +1,208 @@
+// Native structure offsets for glibc, on x86 and x86_64.
+// Generated using GlibcOffsetGen. Do not modify.
+
+using System;
+using System.Runtime.InteropServices;
+namespace GlibcInterop
+{
+    [StructLayout(LayoutKind.Explicit, Size = 4304)]
+    unsafe partial struct rtld_global_2_35_64
+    {
+        [FieldOffset(0)]
+        fixed byte _dl_ns[2560];
+        [FieldOffset(2560)]
+        fixed byte _dl_nns[8];
+        [FieldOffset(2568)]
+        fixed byte _dl_load_lock[40];
+        [FieldOffset(2608)]
+        fixed byte _dl_load_write_lock[40];
+        [FieldOffset(2648)]
+        fixed byte _dl_load_tls_lock[40];
+        [FieldOffset(2688)]
+        fixed byte _dl_load_adds[8];
+        [FieldOffset(2696)]
+        fixed byte _dl_initfirst[8];
+        [FieldOffset(2704)]
+        fixed byte _dl_profile_map[8];
+        [FieldOffset(2712)]
+        fixed byte _dl_num_relocations[8];
+        [FieldOffset(2720)]
+        fixed byte _dl_num_cache_relocations[8];
+        [FieldOffset(2728)]
+        fixed byte _dl_all_dirs[8];
+        [FieldOffset(2736)]
+        fixed byte _dl_rtld_map[1160];
+        [FieldOffset(3896)]
+        fixed byte _dl_rtld_auditstate[256];
+        [FieldOffset(4152)]
+        fixed byte _dl_x86_feature_1[4];
+        [FieldOffset(4156)]
+        fixed byte _dl_x86_feature_control[4];
+        [FieldOffset(4160)]
+        fixed byte _dl_stack_flags[4];
+        [FieldOffset(4164)]
+        fixed byte _dl_tls_dtv_gaps[1];
+        [FieldOffset(4168)]
+        fixed byte _dl_tls_max_dtv_idx[8];
+        [FieldOffset(4176)]
+        fixed byte _dl_tls_dtv_slotinfo_list[8];
+        [FieldOffset(4184)]
+        fixed byte _dl_tls_static_nelem[8];
+        [FieldOffset(4192)]
+        fixed byte _dl_tls_static_used[8];
+        [FieldOffset(4200)]
+        fixed byte _dl_tls_static_optional[8];
+        [FieldOffset(4208)]
+        fixed byte _dl_initial_dtv[8];
+        [FieldOffset(4216)]
+        fixed byte _dl_tls_generation[8];
+        [FieldOffset(4224)]
+        fixed byte _dl_scope_free_list[8];
+        [FieldOffset(4232)]
+        fixed byte _dl_stack_used[16];
+        [FieldOffset(4248)]
+        fixed byte _dl_stack_user[16];
+        [FieldOffset(4264)]
+        fixed byte _dl_stack_cache[16];
+        [FieldOffset(4280)]
+        fixed byte _dl_stack_cache_actsize[8];
+        [FieldOffset(4288)]
+        fixed byte _dl_in_flight_stack[8];
+        [FieldOffset(4296)]
+        fixed byte _dl_stack_cache_lock[4];
+    }
+
+    [StructLayout(LayoutKind.Explicit, Size = 1160)]
+    unsafe partial struct link_map_2_35_64
+    {
+        [FieldOffset(0)]
+        fixed byte l_addr[8];
+        [FieldOffset(8)]
+        fixed byte l_name[8];
+        [FieldOffset(16)]
+        fixed byte l_ld[8];
+        [FieldOffset(24)]
+        fixed byte l_next[8];
+        [FieldOffset(32)]
+        fixed byte l_prev[8];
+        [FieldOffset(40)]
+        fixed byte l_real[8];
+        [FieldOffset(48)]
+        fixed byte l_ns[8];
+        [FieldOffset(56)]
+        fixed byte l_libname[8];
+        [FieldOffset(64)]
+        fixed byte l_info[616];
+        [FieldOffset(680)]
+        fixed byte l_phdr[8];
+        [FieldOffset(688)]
+        fixed byte l_entry[8];
+        [FieldOffset(696)]
+        fixed byte l_phnum[2];
+        [FieldOffset(698)]
+        fixed byte l_ldnum[2];
+        [FieldOffset(704)]
+        fixed byte l_searchlist[16];
+        [FieldOffset(720)]
+        fixed byte l_symbolic_searchlist[16];
+        [FieldOffset(736)]
+        fixed byte l_loader[8];
+        [FieldOffset(744)]
+        fixed byte l_versions[8];
+        [FieldOffset(752)]
+        fixed byte l_nversions[4];
+        [FieldOffset(756)]
+        fixed byte l_nbuckets[4];
+        [FieldOffset(760)]
+        fixed byte l_gnu_bitmask_idxbits[4];
+        [FieldOffset(764)]
+        fixed byte l_gnu_shift[4];
+        [FieldOffset(768)]
+        fixed byte l_gnu_bitmask[8];
+        [FieldOffset(776)]
+        fixed byte l_gnu_buckets[8];
+        [FieldOffset(776)]
+        fixed byte l_chain[8];
+        [FieldOffset(784)]
+        fixed byte l_gnu_chain_zero[8];
+        [FieldOffset(784)]
+        fixed byte l_buckets[8];
+        [FieldOffset(792)]
+        fixed byte l_direct_opencount[4];
+        [FieldOffset(799)]
+        fixed byte l_nodelete_active[1];
+        [FieldOffset(800)]
+        fixed byte l_nodelete_pending[1];
+        [FieldOffset(804)]
+        fixed byte l_x86_feature_1_and[4];
+        [FieldOffset(808)]
+        fixed byte l_x86_isa_1_needed[4];
+        [FieldOffset(812)]
+        fixed byte l_1_needed[4];
+        [FieldOffset(816)]
+        fixed byte l_rpath_dirs[16];
+        [FieldOffset(832)]
+        fixed byte l_reloc_result[8];
+        [FieldOffset(840)]
+        fixed byte l_versyms[8];
+        [FieldOffset(848)]
+        fixed byte l_origin[8];
+        [FieldOffset(856)]
+        fixed byte l_map_start[8];
+        [FieldOffset(864)]
+        fixed byte l_map_end[8];
+        [FieldOffset(872)]
+        fixed byte l_text_end[8];
+        [FieldOffset(880)]
+        fixed byte l_scope_mem[32];
+        [FieldOffset(912)]
+        fixed byte l_scope_max[8];
+        [FieldOffset(928)]
+        fixed byte l_local_scope[16];
+        [FieldOffset(944)]
+        fixed byte l_file_id[16];
+        [FieldOffset(960)]
+        fixed byte l_runpath_dirs[16];
+        [FieldOffset(984)]
+        fixed byte l_reldeps[8];
+        [FieldOffset(992)]
+        fixed byte l_reldepsmax[4];
+        [FieldOffset(996)]
+        fixed byte l_used[4];
+        [FieldOffset(1000)]
+        fixed byte l_feature_1[4];
+        [FieldOffset(1004)]
+        fixed byte l_flags_1[4];
+        [FieldOffset(1008)]
+        fixed byte l_flags[4];
+        [FieldOffset(1012)]
+        fixed byte l_idx[4];
+        [FieldOffset(1016)]
+        fixed byte l_mach[24];
+        [FieldOffset(1040)]
+        fixed byte l_lookup_cache[32];
+        [FieldOffset(1072)]
+        fixed byte l_tls_initimage[8];
+        [FieldOffset(1080)]
+        fixed byte l_tls_initimage_size[8];
+        [FieldOffset(1088)]
+        fixed byte l_tls_blocksize[8];
+        [FieldOffset(1096)]
+        fixed byte l_tls_align[8];
+        [FieldOffset(1104)]
+        fixed byte l_tls_firstbyte_offset[8];
+        [FieldOffset(1112)]
+        fixed byte l_tls_offset[8];
+        [FieldOffset(1120)]
+        fixed byte l_tls_modid[8];
+        [FieldOffset(1128)]
+        fixed byte l_tls_dtor_count[8];
+        [FieldOffset(1136)]
+        fixed byte l_relro_addr[8];
+        [FieldOffset(1144)]
+        fixed byte l_relro_size[8];
+        [FieldOffset(1152)]
+        fixed byte l_serial[8];
+    }
+
+}

--- a/MemoryModule/Linux/GlibcInterop/2_36/32/Natives.g.cs
+++ b/MemoryModule/Linux/GlibcInterop/2_36/32/Natives.g.cs
@@ -1,0 +1,208 @@
+// Native structure offsets for glibc, on x86 and x86_64.
+// Generated using GlibcOffsetGen. Do not modify.
+
+using System;
+using System.Runtime.InteropServices;
+namespace GlibcInterop
+{
+    [StructLayout(LayoutKind.Explicit, Size = 2360)]
+    unsafe partial struct rtld_global_2_36_32
+    {
+        [FieldOffset(0)]
+        fixed byte _dl_ns[1408];
+        [FieldOffset(1408)]
+        fixed byte _dl_nns[4];
+        [FieldOffset(1412)]
+        fixed byte _dl_load_lock[24];
+        [FieldOffset(1436)]
+        fixed byte _dl_load_write_lock[24];
+        [FieldOffset(1460)]
+        fixed byte _dl_load_tls_lock[24];
+        [FieldOffset(1484)]
+        fixed byte _dl_load_adds[8];
+        [FieldOffset(1492)]
+        fixed byte _dl_initfirst[4];
+        [FieldOffset(1496)]
+        fixed byte _dl_profile_map[4];
+        [FieldOffset(1500)]
+        fixed byte _dl_num_relocations[4];
+        [FieldOffset(1504)]
+        fixed byte _dl_num_cache_relocations[4];
+        [FieldOffset(1508)]
+        fixed byte _dl_all_dirs[4];
+        [FieldOffset(1512)]
+        fixed byte _dl_rtld_map[636];
+        [FieldOffset(2148)]
+        fixed byte _dl_rtld_auditstate[128];
+        [FieldOffset(2276)]
+        fixed byte _dl_x86_feature_1[4];
+        [FieldOffset(2280)]
+        fixed byte _dl_x86_feature_control[4];
+        [FieldOffset(2284)]
+        fixed byte _dl_stack_flags[4];
+        [FieldOffset(2288)]
+        fixed byte _dl_tls_dtv_gaps[1];
+        [FieldOffset(2292)]
+        fixed byte _dl_tls_max_dtv_idx[4];
+        [FieldOffset(2296)]
+        fixed byte _dl_tls_dtv_slotinfo_list[4];
+        [FieldOffset(2300)]
+        fixed byte _dl_tls_static_nelem[4];
+        [FieldOffset(2304)]
+        fixed byte _dl_tls_static_used[4];
+        [FieldOffset(2308)]
+        fixed byte _dl_tls_static_optional[4];
+        [FieldOffset(2312)]
+        fixed byte _dl_initial_dtv[4];
+        [FieldOffset(2316)]
+        fixed byte _dl_tls_generation[4];
+        [FieldOffset(2320)]
+        fixed byte _dl_scope_free_list[4];
+        [FieldOffset(2324)]
+        fixed byte _dl_stack_used[8];
+        [FieldOffset(2332)]
+        fixed byte _dl_stack_user[8];
+        [FieldOffset(2340)]
+        fixed byte _dl_stack_cache[8];
+        [FieldOffset(2348)]
+        fixed byte _dl_stack_cache_actsize[4];
+        [FieldOffset(2352)]
+        fixed byte _dl_in_flight_stack[4];
+        [FieldOffset(2356)]
+        fixed byte _dl_stack_cache_lock[4];
+    }
+
+    [StructLayout(LayoutKind.Explicit, Size = 636)]
+    unsafe partial struct link_map_2_36_32
+    {
+        [FieldOffset(0)]
+        fixed byte l_addr[4];
+        [FieldOffset(4)]
+        fixed byte l_name[4];
+        [FieldOffset(8)]
+        fixed byte l_ld[4];
+        [FieldOffset(12)]
+        fixed byte l_next[4];
+        [FieldOffset(16)]
+        fixed byte l_prev[4];
+        [FieldOffset(20)]
+        fixed byte l_real[4];
+        [FieldOffset(24)]
+        fixed byte l_ns[4];
+        [FieldOffset(28)]
+        fixed byte l_libname[4];
+        [FieldOffset(32)]
+        fixed byte l_info[320];
+        [FieldOffset(352)]
+        fixed byte l_phdr[4];
+        [FieldOffset(356)]
+        fixed byte l_entry[4];
+        [FieldOffset(360)]
+        fixed byte l_phnum[2];
+        [FieldOffset(362)]
+        fixed byte l_ldnum[2];
+        [FieldOffset(364)]
+        fixed byte l_searchlist[8];
+        [FieldOffset(372)]
+        fixed byte l_symbolic_searchlist[8];
+        [FieldOffset(380)]
+        fixed byte l_loader[4];
+        [FieldOffset(384)]
+        fixed byte l_versions[4];
+        [FieldOffset(388)]
+        fixed byte l_nversions[4];
+        [FieldOffset(392)]
+        fixed byte l_nbuckets[4];
+        [FieldOffset(396)]
+        fixed byte l_gnu_bitmask_idxbits[4];
+        [FieldOffset(400)]
+        fixed byte l_gnu_shift[4];
+        [FieldOffset(404)]
+        fixed byte l_gnu_bitmask[4];
+        [FieldOffset(408)]
+        fixed byte l_gnu_buckets[4];
+        [FieldOffset(408)]
+        fixed byte l_chain[4];
+        [FieldOffset(412)]
+        fixed byte l_gnu_chain_zero[4];
+        [FieldOffset(412)]
+        fixed byte l_buckets[4];
+        [FieldOffset(416)]
+        fixed byte l_direct_opencount[4];
+        [FieldOffset(423)]
+        fixed byte l_nodelete_active[1];
+        [FieldOffset(424)]
+        fixed byte l_nodelete_pending[1];
+        [FieldOffset(428)]
+        fixed byte l_x86_feature_1_and[4];
+        [FieldOffset(432)]
+        fixed byte l_x86_isa_1_needed[4];
+        [FieldOffset(436)]
+        fixed byte l_1_needed[4];
+        [FieldOffset(440)]
+        fixed byte l_rpath_dirs[8];
+        [FieldOffset(448)]
+        fixed byte l_reloc_result[4];
+        [FieldOffset(452)]
+        fixed byte l_versyms[4];
+        [FieldOffset(456)]
+        fixed byte l_origin[4];
+        [FieldOffset(460)]
+        fixed byte l_map_start[4];
+        [FieldOffset(464)]
+        fixed byte l_map_end[4];
+        [FieldOffset(468)]
+        fixed byte l_text_end[4];
+        [FieldOffset(472)]
+        fixed byte l_scope_mem[16];
+        [FieldOffset(488)]
+        fixed byte l_scope_max[4];
+        [FieldOffset(496)]
+        fixed byte l_local_scope[8];
+        [FieldOffset(504)]
+        fixed byte l_file_id[16];
+        [FieldOffset(520)]
+        fixed byte l_runpath_dirs[8];
+        [FieldOffset(532)]
+        fixed byte l_reldeps[4];
+        [FieldOffset(536)]
+        fixed byte l_reldepsmax[4];
+        [FieldOffset(540)]
+        fixed byte l_used[4];
+        [FieldOffset(544)]
+        fixed byte l_feature_1[4];
+        [FieldOffset(548)]
+        fixed byte l_flags_1[4];
+        [FieldOffset(552)]
+        fixed byte l_flags[4];
+        [FieldOffset(556)]
+        fixed byte l_idx[4];
+        [FieldOffset(560)]
+        fixed byte l_mach[12];
+        [FieldOffset(572)]
+        fixed byte l_lookup_cache[16];
+        [FieldOffset(588)]
+        fixed byte l_tls_initimage[4];
+        [FieldOffset(592)]
+        fixed byte l_tls_initimage_size[4];
+        [FieldOffset(596)]
+        fixed byte l_tls_blocksize[4];
+        [FieldOffset(600)]
+        fixed byte l_tls_align[4];
+        [FieldOffset(604)]
+        fixed byte l_tls_firstbyte_offset[4];
+        [FieldOffset(608)]
+        fixed byte l_tls_offset[4];
+        [FieldOffset(612)]
+        fixed byte l_tls_modid[4];
+        [FieldOffset(616)]
+        fixed byte l_tls_dtor_count[4];
+        [FieldOffset(620)]
+        fixed byte l_relro_addr[4];
+        [FieldOffset(624)]
+        fixed byte l_relro_size[4];
+        [FieldOffset(628)]
+        fixed byte l_serial[8];
+    }
+
+}

--- a/MemoryModule/Linux/GlibcInterop/2_36/64/Natives.g.cs
+++ b/MemoryModule/Linux/GlibcInterop/2_36/64/Natives.g.cs
@@ -1,0 +1,208 @@
+// Native structure offsets for glibc, on x86 and x86_64.
+// Generated using GlibcOffsetGen. Do not modify.
+
+using System;
+using System.Runtime.InteropServices;
+namespace GlibcInterop
+{
+    [StructLayout(LayoutKind.Explicit, Size = 4328)]
+    unsafe partial struct rtld_global_2_36_64
+    {
+        [FieldOffset(0)]
+        fixed byte _dl_ns[2560];
+        [FieldOffset(2560)]
+        fixed byte _dl_nns[8];
+        [FieldOffset(2568)]
+        fixed byte _dl_load_lock[40];
+        [FieldOffset(2608)]
+        fixed byte _dl_load_write_lock[40];
+        [FieldOffset(2648)]
+        fixed byte _dl_load_tls_lock[40];
+        [FieldOffset(2688)]
+        fixed byte _dl_load_adds[8];
+        [FieldOffset(2696)]
+        fixed byte _dl_initfirst[8];
+        [FieldOffset(2704)]
+        fixed byte _dl_profile_map[8];
+        [FieldOffset(2712)]
+        fixed byte _dl_num_relocations[8];
+        [FieldOffset(2720)]
+        fixed byte _dl_num_cache_relocations[8];
+        [FieldOffset(2728)]
+        fixed byte _dl_all_dirs[8];
+        [FieldOffset(2736)]
+        fixed byte _dl_rtld_map[1184];
+        [FieldOffset(3920)]
+        fixed byte _dl_rtld_auditstate[256];
+        [FieldOffset(4176)]
+        fixed byte _dl_x86_feature_1[4];
+        [FieldOffset(4180)]
+        fixed byte _dl_x86_feature_control[4];
+        [FieldOffset(4184)]
+        fixed byte _dl_stack_flags[4];
+        [FieldOffset(4188)]
+        fixed byte _dl_tls_dtv_gaps[1];
+        [FieldOffset(4192)]
+        fixed byte _dl_tls_max_dtv_idx[8];
+        [FieldOffset(4200)]
+        fixed byte _dl_tls_dtv_slotinfo_list[8];
+        [FieldOffset(4208)]
+        fixed byte _dl_tls_static_nelem[8];
+        [FieldOffset(4216)]
+        fixed byte _dl_tls_static_used[8];
+        [FieldOffset(4224)]
+        fixed byte _dl_tls_static_optional[8];
+        [FieldOffset(4232)]
+        fixed byte _dl_initial_dtv[8];
+        [FieldOffset(4240)]
+        fixed byte _dl_tls_generation[8];
+        [FieldOffset(4248)]
+        fixed byte _dl_scope_free_list[8];
+        [FieldOffset(4256)]
+        fixed byte _dl_stack_used[16];
+        [FieldOffset(4272)]
+        fixed byte _dl_stack_user[16];
+        [FieldOffset(4288)]
+        fixed byte _dl_stack_cache[16];
+        [FieldOffset(4304)]
+        fixed byte _dl_stack_cache_actsize[8];
+        [FieldOffset(4312)]
+        fixed byte _dl_in_flight_stack[8];
+        [FieldOffset(4320)]
+        fixed byte _dl_stack_cache_lock[4];
+    }
+
+    [StructLayout(LayoutKind.Explicit, Size = 1184)]
+    unsafe partial struct link_map_2_36_64
+    {
+        [FieldOffset(0)]
+        fixed byte l_addr[8];
+        [FieldOffset(8)]
+        fixed byte l_name[8];
+        [FieldOffset(16)]
+        fixed byte l_ld[8];
+        [FieldOffset(24)]
+        fixed byte l_next[8];
+        [FieldOffset(32)]
+        fixed byte l_prev[8];
+        [FieldOffset(40)]
+        fixed byte l_real[8];
+        [FieldOffset(48)]
+        fixed byte l_ns[8];
+        [FieldOffset(56)]
+        fixed byte l_libname[8];
+        [FieldOffset(64)]
+        fixed byte l_info[640];
+        [FieldOffset(704)]
+        fixed byte l_phdr[8];
+        [FieldOffset(712)]
+        fixed byte l_entry[8];
+        [FieldOffset(720)]
+        fixed byte l_phnum[2];
+        [FieldOffset(722)]
+        fixed byte l_ldnum[2];
+        [FieldOffset(728)]
+        fixed byte l_searchlist[16];
+        [FieldOffset(744)]
+        fixed byte l_symbolic_searchlist[16];
+        [FieldOffset(760)]
+        fixed byte l_loader[8];
+        [FieldOffset(768)]
+        fixed byte l_versions[8];
+        [FieldOffset(776)]
+        fixed byte l_nversions[4];
+        [FieldOffset(780)]
+        fixed byte l_nbuckets[4];
+        [FieldOffset(784)]
+        fixed byte l_gnu_bitmask_idxbits[4];
+        [FieldOffset(788)]
+        fixed byte l_gnu_shift[4];
+        [FieldOffset(792)]
+        fixed byte l_gnu_bitmask[8];
+        [FieldOffset(800)]
+        fixed byte l_gnu_buckets[8];
+        [FieldOffset(800)]
+        fixed byte l_chain[8];
+        [FieldOffset(808)]
+        fixed byte l_gnu_chain_zero[8];
+        [FieldOffset(808)]
+        fixed byte l_buckets[8];
+        [FieldOffset(816)]
+        fixed byte l_direct_opencount[4];
+        [FieldOffset(823)]
+        fixed byte l_nodelete_active[1];
+        [FieldOffset(824)]
+        fixed byte l_nodelete_pending[1];
+        [FieldOffset(828)]
+        fixed byte l_x86_feature_1_and[4];
+        [FieldOffset(832)]
+        fixed byte l_x86_isa_1_needed[4];
+        [FieldOffset(836)]
+        fixed byte l_1_needed[4];
+        [FieldOffset(840)]
+        fixed byte l_rpath_dirs[16];
+        [FieldOffset(856)]
+        fixed byte l_reloc_result[8];
+        [FieldOffset(864)]
+        fixed byte l_versyms[8];
+        [FieldOffset(872)]
+        fixed byte l_origin[8];
+        [FieldOffset(880)]
+        fixed byte l_map_start[8];
+        [FieldOffset(888)]
+        fixed byte l_map_end[8];
+        [FieldOffset(896)]
+        fixed byte l_text_end[8];
+        [FieldOffset(904)]
+        fixed byte l_scope_mem[32];
+        [FieldOffset(936)]
+        fixed byte l_scope_max[8];
+        [FieldOffset(952)]
+        fixed byte l_local_scope[16];
+        [FieldOffset(968)]
+        fixed byte l_file_id[16];
+        [FieldOffset(984)]
+        fixed byte l_runpath_dirs[16];
+        [FieldOffset(1008)]
+        fixed byte l_reldeps[8];
+        [FieldOffset(1016)]
+        fixed byte l_reldepsmax[4];
+        [FieldOffset(1020)]
+        fixed byte l_used[4];
+        [FieldOffset(1024)]
+        fixed byte l_feature_1[4];
+        [FieldOffset(1028)]
+        fixed byte l_flags_1[4];
+        [FieldOffset(1032)]
+        fixed byte l_flags[4];
+        [FieldOffset(1036)]
+        fixed byte l_idx[4];
+        [FieldOffset(1040)]
+        fixed byte l_mach[24];
+        [FieldOffset(1064)]
+        fixed byte l_lookup_cache[32];
+        [FieldOffset(1096)]
+        fixed byte l_tls_initimage[8];
+        [FieldOffset(1104)]
+        fixed byte l_tls_initimage_size[8];
+        [FieldOffset(1112)]
+        fixed byte l_tls_blocksize[8];
+        [FieldOffset(1120)]
+        fixed byte l_tls_align[8];
+        [FieldOffset(1128)]
+        fixed byte l_tls_firstbyte_offset[8];
+        [FieldOffset(1136)]
+        fixed byte l_tls_offset[8];
+        [FieldOffset(1144)]
+        fixed byte l_tls_modid[8];
+        [FieldOffset(1152)]
+        fixed byte l_tls_dtor_count[8];
+        [FieldOffset(1160)]
+        fixed byte l_relro_addr[8];
+        [FieldOffset(1168)]
+        fixed byte l_relro_size[8];
+        [FieldOffset(1176)]
+        fixed byte l_serial[8];
+    }
+
+}

--- a/MemoryModule/Linux/GlibcInterop/2_37/32/Natives.g.cs
+++ b/MemoryModule/Linux/GlibcInterop/2_37/32/Natives.g.cs
@@ -1,0 +1,208 @@
+// Native structure offsets for glibc, on x86 and x86_64.
+// Generated using GlibcOffsetGen. Do not modify.
+
+using System;
+using System.Runtime.InteropServices;
+namespace GlibcInterop
+{
+    [StructLayout(LayoutKind.Explicit, Size = 2360)]
+    unsafe partial struct rtld_global_2_37_32
+    {
+        [FieldOffset(0)]
+        fixed byte _dl_ns[1408];
+        [FieldOffset(1408)]
+        fixed byte _dl_nns[4];
+        [FieldOffset(1412)]
+        fixed byte _dl_load_lock[24];
+        [FieldOffset(1436)]
+        fixed byte _dl_load_write_lock[24];
+        [FieldOffset(1460)]
+        fixed byte _dl_load_tls_lock[24];
+        [FieldOffset(1484)]
+        fixed byte _dl_load_adds[8];
+        [FieldOffset(1492)]
+        fixed byte _dl_initfirst[4];
+        [FieldOffset(1496)]
+        fixed byte _dl_profile_map[4];
+        [FieldOffset(1500)]
+        fixed byte _dl_num_relocations[4];
+        [FieldOffset(1504)]
+        fixed byte _dl_num_cache_relocations[4];
+        [FieldOffset(1508)]
+        fixed byte _dl_all_dirs[4];
+        [FieldOffset(1512)]
+        fixed byte _dl_rtld_map[636];
+        [FieldOffset(2148)]
+        fixed byte _dl_rtld_auditstate[128];
+        [FieldOffset(2276)]
+        fixed byte _dl_x86_feature_1[4];
+        [FieldOffset(2280)]
+        fixed byte _dl_x86_feature_control[4];
+        [FieldOffset(2284)]
+        fixed byte _dl_stack_flags[4];
+        [FieldOffset(2288)]
+        fixed byte _dl_tls_dtv_gaps[1];
+        [FieldOffset(2292)]
+        fixed byte _dl_tls_max_dtv_idx[4];
+        [FieldOffset(2296)]
+        fixed byte _dl_tls_dtv_slotinfo_list[4];
+        [FieldOffset(2300)]
+        fixed byte _dl_tls_static_nelem[4];
+        [FieldOffset(2304)]
+        fixed byte _dl_tls_static_used[4];
+        [FieldOffset(2308)]
+        fixed byte _dl_tls_static_optional[4];
+        [FieldOffset(2312)]
+        fixed byte _dl_initial_dtv[4];
+        [FieldOffset(2316)]
+        fixed byte _dl_tls_generation[4];
+        [FieldOffset(2320)]
+        fixed byte _dl_scope_free_list[4];
+        [FieldOffset(2324)]
+        fixed byte _dl_stack_used[8];
+        [FieldOffset(2332)]
+        fixed byte _dl_stack_user[8];
+        [FieldOffset(2340)]
+        fixed byte _dl_stack_cache[8];
+        [FieldOffset(2348)]
+        fixed byte _dl_stack_cache_actsize[4];
+        [FieldOffset(2352)]
+        fixed byte _dl_in_flight_stack[4];
+        [FieldOffset(2356)]
+        fixed byte _dl_stack_cache_lock[4];
+    }
+
+    [StructLayout(LayoutKind.Explicit, Size = 636)]
+    unsafe partial struct link_map_2_37_32
+    {
+        [FieldOffset(0)]
+        fixed byte l_addr[4];
+        [FieldOffset(4)]
+        fixed byte l_name[4];
+        [FieldOffset(8)]
+        fixed byte l_ld[4];
+        [FieldOffset(12)]
+        fixed byte l_next[4];
+        [FieldOffset(16)]
+        fixed byte l_prev[4];
+        [FieldOffset(20)]
+        fixed byte l_real[4];
+        [FieldOffset(24)]
+        fixed byte l_ns[4];
+        [FieldOffset(28)]
+        fixed byte l_libname[4];
+        [FieldOffset(32)]
+        fixed byte l_info[320];
+        [FieldOffset(352)]
+        fixed byte l_phdr[4];
+        [FieldOffset(356)]
+        fixed byte l_entry[4];
+        [FieldOffset(360)]
+        fixed byte l_phnum[2];
+        [FieldOffset(362)]
+        fixed byte l_ldnum[2];
+        [FieldOffset(364)]
+        fixed byte l_searchlist[8];
+        [FieldOffset(372)]
+        fixed byte l_symbolic_searchlist[8];
+        [FieldOffset(380)]
+        fixed byte l_loader[4];
+        [FieldOffset(384)]
+        fixed byte l_versions[4];
+        [FieldOffset(388)]
+        fixed byte l_nversions[4];
+        [FieldOffset(392)]
+        fixed byte l_nbuckets[4];
+        [FieldOffset(396)]
+        fixed byte l_gnu_bitmask_idxbits[4];
+        [FieldOffset(400)]
+        fixed byte l_gnu_shift[4];
+        [FieldOffset(404)]
+        fixed byte l_gnu_bitmask[4];
+        [FieldOffset(408)]
+        fixed byte l_gnu_buckets[4];
+        [FieldOffset(408)]
+        fixed byte l_chain[4];
+        [FieldOffset(412)]
+        fixed byte l_gnu_chain_zero[4];
+        [FieldOffset(412)]
+        fixed byte l_buckets[4];
+        [FieldOffset(416)]
+        fixed byte l_direct_opencount[4];
+        [FieldOffset(423)]
+        fixed byte l_nodelete_active[1];
+        [FieldOffset(424)]
+        fixed byte l_nodelete_pending[1];
+        [FieldOffset(428)]
+        fixed byte l_x86_feature_1_and[4];
+        [FieldOffset(432)]
+        fixed byte l_x86_isa_1_needed[4];
+        [FieldOffset(436)]
+        fixed byte l_1_needed[4];
+        [FieldOffset(440)]
+        fixed byte l_rpath_dirs[8];
+        [FieldOffset(448)]
+        fixed byte l_reloc_result[4];
+        [FieldOffset(452)]
+        fixed byte l_versyms[4];
+        [FieldOffset(456)]
+        fixed byte l_origin[4];
+        [FieldOffset(460)]
+        fixed byte l_map_start[4];
+        [FieldOffset(464)]
+        fixed byte l_map_end[4];
+        [FieldOffset(468)]
+        fixed byte l_text_end[4];
+        [FieldOffset(472)]
+        fixed byte l_scope_mem[16];
+        [FieldOffset(488)]
+        fixed byte l_scope_max[4];
+        [FieldOffset(496)]
+        fixed byte l_local_scope[8];
+        [FieldOffset(504)]
+        fixed byte l_file_id[16];
+        [FieldOffset(520)]
+        fixed byte l_runpath_dirs[8];
+        [FieldOffset(532)]
+        fixed byte l_reldeps[4];
+        [FieldOffset(536)]
+        fixed byte l_reldepsmax[4];
+        [FieldOffset(540)]
+        fixed byte l_used[4];
+        [FieldOffset(544)]
+        fixed byte l_feature_1[4];
+        [FieldOffset(548)]
+        fixed byte l_flags_1[4];
+        [FieldOffset(552)]
+        fixed byte l_flags[4];
+        [FieldOffset(556)]
+        fixed byte l_idx[4];
+        [FieldOffset(560)]
+        fixed byte l_mach[12];
+        [FieldOffset(572)]
+        fixed byte l_lookup_cache[16];
+        [FieldOffset(588)]
+        fixed byte l_tls_initimage[4];
+        [FieldOffset(592)]
+        fixed byte l_tls_initimage_size[4];
+        [FieldOffset(596)]
+        fixed byte l_tls_blocksize[4];
+        [FieldOffset(600)]
+        fixed byte l_tls_align[4];
+        [FieldOffset(604)]
+        fixed byte l_tls_firstbyte_offset[4];
+        [FieldOffset(608)]
+        fixed byte l_tls_offset[4];
+        [FieldOffset(612)]
+        fixed byte l_tls_modid[4];
+        [FieldOffset(616)]
+        fixed byte l_tls_dtor_count[4];
+        [FieldOffset(620)]
+        fixed byte l_relro_addr[4];
+        [FieldOffset(624)]
+        fixed byte l_relro_size[4];
+        [FieldOffset(628)]
+        fixed byte l_serial[8];
+    }
+
+}

--- a/MemoryModule/Linux/GlibcInterop/2_37/64/Natives.g.cs
+++ b/MemoryModule/Linux/GlibcInterop/2_37/64/Natives.g.cs
@@ -1,0 +1,208 @@
+// Native structure offsets for glibc, on x86 and x86_64.
+// Generated using GlibcOffsetGen. Do not modify.
+
+using System;
+using System.Runtime.InteropServices;
+namespace GlibcInterop
+{
+    [StructLayout(LayoutKind.Explicit, Size = 4328)]
+    unsafe partial struct rtld_global_2_37_64
+    {
+        [FieldOffset(0)]
+        fixed byte _dl_ns[2560];
+        [FieldOffset(2560)]
+        fixed byte _dl_nns[8];
+        [FieldOffset(2568)]
+        fixed byte _dl_load_lock[40];
+        [FieldOffset(2608)]
+        fixed byte _dl_load_write_lock[40];
+        [FieldOffset(2648)]
+        fixed byte _dl_load_tls_lock[40];
+        [FieldOffset(2688)]
+        fixed byte _dl_load_adds[8];
+        [FieldOffset(2696)]
+        fixed byte _dl_initfirst[8];
+        [FieldOffset(2704)]
+        fixed byte _dl_profile_map[8];
+        [FieldOffset(2712)]
+        fixed byte _dl_num_relocations[8];
+        [FieldOffset(2720)]
+        fixed byte _dl_num_cache_relocations[8];
+        [FieldOffset(2728)]
+        fixed byte _dl_all_dirs[8];
+        [FieldOffset(2736)]
+        fixed byte _dl_rtld_map[1184];
+        [FieldOffset(3920)]
+        fixed byte _dl_rtld_auditstate[256];
+        [FieldOffset(4176)]
+        fixed byte _dl_x86_feature_1[4];
+        [FieldOffset(4180)]
+        fixed byte _dl_x86_feature_control[4];
+        [FieldOffset(4184)]
+        fixed byte _dl_stack_flags[4];
+        [FieldOffset(4188)]
+        fixed byte _dl_tls_dtv_gaps[1];
+        [FieldOffset(4192)]
+        fixed byte _dl_tls_max_dtv_idx[8];
+        [FieldOffset(4200)]
+        fixed byte _dl_tls_dtv_slotinfo_list[8];
+        [FieldOffset(4208)]
+        fixed byte _dl_tls_static_nelem[8];
+        [FieldOffset(4216)]
+        fixed byte _dl_tls_static_used[8];
+        [FieldOffset(4224)]
+        fixed byte _dl_tls_static_optional[8];
+        [FieldOffset(4232)]
+        fixed byte _dl_initial_dtv[8];
+        [FieldOffset(4240)]
+        fixed byte _dl_tls_generation[8];
+        [FieldOffset(4248)]
+        fixed byte _dl_scope_free_list[8];
+        [FieldOffset(4256)]
+        fixed byte _dl_stack_used[16];
+        [FieldOffset(4272)]
+        fixed byte _dl_stack_user[16];
+        [FieldOffset(4288)]
+        fixed byte _dl_stack_cache[16];
+        [FieldOffset(4304)]
+        fixed byte _dl_stack_cache_actsize[8];
+        [FieldOffset(4312)]
+        fixed byte _dl_in_flight_stack[8];
+        [FieldOffset(4320)]
+        fixed byte _dl_stack_cache_lock[4];
+    }
+
+    [StructLayout(LayoutKind.Explicit, Size = 1184)]
+    unsafe partial struct link_map_2_37_64
+    {
+        [FieldOffset(0)]
+        fixed byte l_addr[8];
+        [FieldOffset(8)]
+        fixed byte l_name[8];
+        [FieldOffset(16)]
+        fixed byte l_ld[8];
+        [FieldOffset(24)]
+        fixed byte l_next[8];
+        [FieldOffset(32)]
+        fixed byte l_prev[8];
+        [FieldOffset(40)]
+        fixed byte l_real[8];
+        [FieldOffset(48)]
+        fixed byte l_ns[8];
+        [FieldOffset(56)]
+        fixed byte l_libname[8];
+        [FieldOffset(64)]
+        fixed byte l_info[640];
+        [FieldOffset(704)]
+        fixed byte l_phdr[8];
+        [FieldOffset(712)]
+        fixed byte l_entry[8];
+        [FieldOffset(720)]
+        fixed byte l_phnum[2];
+        [FieldOffset(722)]
+        fixed byte l_ldnum[2];
+        [FieldOffset(728)]
+        fixed byte l_searchlist[16];
+        [FieldOffset(744)]
+        fixed byte l_symbolic_searchlist[16];
+        [FieldOffset(760)]
+        fixed byte l_loader[8];
+        [FieldOffset(768)]
+        fixed byte l_versions[8];
+        [FieldOffset(776)]
+        fixed byte l_nversions[4];
+        [FieldOffset(780)]
+        fixed byte l_nbuckets[4];
+        [FieldOffset(784)]
+        fixed byte l_gnu_bitmask_idxbits[4];
+        [FieldOffset(788)]
+        fixed byte l_gnu_shift[4];
+        [FieldOffset(792)]
+        fixed byte l_gnu_bitmask[8];
+        [FieldOffset(800)]
+        fixed byte l_gnu_buckets[8];
+        [FieldOffset(800)]
+        fixed byte l_chain[8];
+        [FieldOffset(808)]
+        fixed byte l_gnu_chain_zero[8];
+        [FieldOffset(808)]
+        fixed byte l_buckets[8];
+        [FieldOffset(816)]
+        fixed byte l_direct_opencount[4];
+        [FieldOffset(823)]
+        fixed byte l_nodelete_active[1];
+        [FieldOffset(824)]
+        fixed byte l_nodelete_pending[1];
+        [FieldOffset(828)]
+        fixed byte l_x86_feature_1_and[4];
+        [FieldOffset(832)]
+        fixed byte l_x86_isa_1_needed[4];
+        [FieldOffset(836)]
+        fixed byte l_1_needed[4];
+        [FieldOffset(840)]
+        fixed byte l_rpath_dirs[16];
+        [FieldOffset(856)]
+        fixed byte l_reloc_result[8];
+        [FieldOffset(864)]
+        fixed byte l_versyms[8];
+        [FieldOffset(872)]
+        fixed byte l_origin[8];
+        [FieldOffset(880)]
+        fixed byte l_map_start[8];
+        [FieldOffset(888)]
+        fixed byte l_map_end[8];
+        [FieldOffset(896)]
+        fixed byte l_text_end[8];
+        [FieldOffset(904)]
+        fixed byte l_scope_mem[32];
+        [FieldOffset(936)]
+        fixed byte l_scope_max[8];
+        [FieldOffset(952)]
+        fixed byte l_local_scope[16];
+        [FieldOffset(968)]
+        fixed byte l_file_id[16];
+        [FieldOffset(984)]
+        fixed byte l_runpath_dirs[16];
+        [FieldOffset(1008)]
+        fixed byte l_reldeps[8];
+        [FieldOffset(1016)]
+        fixed byte l_reldepsmax[4];
+        [FieldOffset(1020)]
+        fixed byte l_used[4];
+        [FieldOffset(1024)]
+        fixed byte l_feature_1[4];
+        [FieldOffset(1028)]
+        fixed byte l_flags_1[4];
+        [FieldOffset(1032)]
+        fixed byte l_flags[4];
+        [FieldOffset(1036)]
+        fixed byte l_idx[4];
+        [FieldOffset(1040)]
+        fixed byte l_mach[24];
+        [FieldOffset(1064)]
+        fixed byte l_lookup_cache[32];
+        [FieldOffset(1096)]
+        fixed byte l_tls_initimage[8];
+        [FieldOffset(1104)]
+        fixed byte l_tls_initimage_size[8];
+        [FieldOffset(1112)]
+        fixed byte l_tls_blocksize[8];
+        [FieldOffset(1120)]
+        fixed byte l_tls_align[8];
+        [FieldOffset(1128)]
+        fixed byte l_tls_firstbyte_offset[8];
+        [FieldOffset(1136)]
+        fixed byte l_tls_offset[8];
+        [FieldOffset(1144)]
+        fixed byte l_tls_modid[8];
+        [FieldOffset(1152)]
+        fixed byte l_tls_dtor_count[8];
+        [FieldOffset(1160)]
+        fixed byte l_relro_addr[8];
+        [FieldOffset(1168)]
+        fixed byte l_relro_size[8];
+        [FieldOffset(1176)]
+        fixed byte l_serial[8];
+    }
+
+}

--- a/MemoryModule/Linux/GlibcInterop/2_38/32/Natives.g.cs
+++ b/MemoryModule/Linux/GlibcInterop/2_38/32/Natives.g.cs
@@ -1,0 +1,208 @@
+// Native structure offsets for glibc, on x86 and x86_64.
+// Generated using GlibcOffsetGen. Do not modify.
+
+using System;
+using System.Runtime.InteropServices;
+namespace GlibcInterop
+{
+    [StructLayout(LayoutKind.Explicit, Size = 2360)]
+    unsafe partial struct rtld_global_2_38_32
+    {
+        [FieldOffset(0)]
+        fixed byte _dl_ns[1408];
+        [FieldOffset(1408)]
+        fixed byte _dl_nns[4];
+        [FieldOffset(1412)]
+        fixed byte _dl_load_lock[24];
+        [FieldOffset(1436)]
+        fixed byte _dl_load_write_lock[24];
+        [FieldOffset(1460)]
+        fixed byte _dl_load_tls_lock[24];
+        [FieldOffset(1484)]
+        fixed byte _dl_load_adds[8];
+        [FieldOffset(1492)]
+        fixed byte _dl_initfirst[4];
+        [FieldOffset(1496)]
+        fixed byte _dl_profile_map[4];
+        [FieldOffset(1500)]
+        fixed byte _dl_num_relocations[4];
+        [FieldOffset(1504)]
+        fixed byte _dl_num_cache_relocations[4];
+        [FieldOffset(1508)]
+        fixed byte _dl_all_dirs[4];
+        [FieldOffset(1512)]
+        fixed byte _dl_rtld_map[636];
+        [FieldOffset(2148)]
+        fixed byte _dl_rtld_auditstate[128];
+        [FieldOffset(2276)]
+        fixed byte _dl_x86_feature_1[4];
+        [FieldOffset(2280)]
+        fixed byte _dl_x86_feature_control[4];
+        [FieldOffset(2284)]
+        fixed byte _dl_stack_flags[4];
+        [FieldOffset(2288)]
+        fixed byte _dl_tls_dtv_gaps[1];
+        [FieldOffset(2292)]
+        fixed byte _dl_tls_max_dtv_idx[4];
+        [FieldOffset(2296)]
+        fixed byte _dl_tls_dtv_slotinfo_list[4];
+        [FieldOffset(2300)]
+        fixed byte _dl_tls_static_nelem[4];
+        [FieldOffset(2304)]
+        fixed byte _dl_tls_static_used[4];
+        [FieldOffset(2308)]
+        fixed byte _dl_tls_static_optional[4];
+        [FieldOffset(2312)]
+        fixed byte _dl_initial_dtv[4];
+        [FieldOffset(2316)]
+        fixed byte _dl_tls_generation[4];
+        [FieldOffset(2320)]
+        fixed byte _dl_scope_free_list[4];
+        [FieldOffset(2324)]
+        fixed byte _dl_stack_used[8];
+        [FieldOffset(2332)]
+        fixed byte _dl_stack_user[8];
+        [FieldOffset(2340)]
+        fixed byte _dl_stack_cache[8];
+        [FieldOffset(2348)]
+        fixed byte _dl_stack_cache_actsize[4];
+        [FieldOffset(2352)]
+        fixed byte _dl_in_flight_stack[4];
+        [FieldOffset(2356)]
+        fixed byte _dl_stack_cache_lock[4];
+    }
+
+    [StructLayout(LayoutKind.Explicit, Size = 636)]
+    unsafe partial struct link_map_2_38_32
+    {
+        [FieldOffset(0)]
+        fixed byte l_addr[4];
+        [FieldOffset(4)]
+        fixed byte l_name[4];
+        [FieldOffset(8)]
+        fixed byte l_ld[4];
+        [FieldOffset(12)]
+        fixed byte l_next[4];
+        [FieldOffset(16)]
+        fixed byte l_prev[4];
+        [FieldOffset(20)]
+        fixed byte l_real[4];
+        [FieldOffset(24)]
+        fixed byte l_ns[4];
+        [FieldOffset(28)]
+        fixed byte l_libname[4];
+        [FieldOffset(32)]
+        fixed byte l_info[320];
+        [FieldOffset(352)]
+        fixed byte l_phdr[4];
+        [FieldOffset(356)]
+        fixed byte l_entry[4];
+        [FieldOffset(360)]
+        fixed byte l_phnum[2];
+        [FieldOffset(362)]
+        fixed byte l_ldnum[2];
+        [FieldOffset(364)]
+        fixed byte l_searchlist[8];
+        [FieldOffset(372)]
+        fixed byte l_symbolic_searchlist[8];
+        [FieldOffset(380)]
+        fixed byte l_loader[4];
+        [FieldOffset(384)]
+        fixed byte l_versions[4];
+        [FieldOffset(388)]
+        fixed byte l_nversions[4];
+        [FieldOffset(392)]
+        fixed byte l_nbuckets[4];
+        [FieldOffset(396)]
+        fixed byte l_gnu_bitmask_idxbits[4];
+        [FieldOffset(400)]
+        fixed byte l_gnu_shift[4];
+        [FieldOffset(404)]
+        fixed byte l_gnu_bitmask[4];
+        [FieldOffset(408)]
+        fixed byte l_gnu_buckets[4];
+        [FieldOffset(408)]
+        fixed byte l_chain[4];
+        [FieldOffset(412)]
+        fixed byte l_gnu_chain_zero[4];
+        [FieldOffset(412)]
+        fixed byte l_buckets[4];
+        [FieldOffset(416)]
+        fixed byte l_direct_opencount[4];
+        [FieldOffset(423)]
+        fixed byte l_nodelete_active[1];
+        [FieldOffset(424)]
+        fixed byte l_nodelete_pending[1];
+        [FieldOffset(428)]
+        fixed byte l_x86_feature_1_and[4];
+        [FieldOffset(432)]
+        fixed byte l_x86_isa_1_needed[4];
+        [FieldOffset(436)]
+        fixed byte l_1_needed[4];
+        [FieldOffset(440)]
+        fixed byte l_rpath_dirs[8];
+        [FieldOffset(448)]
+        fixed byte l_reloc_result[4];
+        [FieldOffset(452)]
+        fixed byte l_versyms[4];
+        [FieldOffset(456)]
+        fixed byte l_origin[4];
+        [FieldOffset(460)]
+        fixed byte l_map_start[4];
+        [FieldOffset(464)]
+        fixed byte l_map_end[4];
+        [FieldOffset(468)]
+        fixed byte l_text_end[4];
+        [FieldOffset(472)]
+        fixed byte l_scope_mem[16];
+        [FieldOffset(488)]
+        fixed byte l_scope_max[4];
+        [FieldOffset(496)]
+        fixed byte l_local_scope[8];
+        [FieldOffset(504)]
+        fixed byte l_file_id[16];
+        [FieldOffset(520)]
+        fixed byte l_runpath_dirs[8];
+        [FieldOffset(532)]
+        fixed byte l_reldeps[4];
+        [FieldOffset(536)]
+        fixed byte l_reldepsmax[4];
+        [FieldOffset(540)]
+        fixed byte l_used[4];
+        [FieldOffset(544)]
+        fixed byte l_feature_1[4];
+        [FieldOffset(548)]
+        fixed byte l_flags_1[4];
+        [FieldOffset(552)]
+        fixed byte l_flags[4];
+        [FieldOffset(556)]
+        fixed byte l_idx[4];
+        [FieldOffset(560)]
+        fixed byte l_mach[12];
+        [FieldOffset(572)]
+        fixed byte l_lookup_cache[16];
+        [FieldOffset(588)]
+        fixed byte l_tls_initimage[4];
+        [FieldOffset(592)]
+        fixed byte l_tls_initimage_size[4];
+        [FieldOffset(596)]
+        fixed byte l_tls_blocksize[4];
+        [FieldOffset(600)]
+        fixed byte l_tls_align[4];
+        [FieldOffset(604)]
+        fixed byte l_tls_firstbyte_offset[4];
+        [FieldOffset(608)]
+        fixed byte l_tls_offset[4];
+        [FieldOffset(612)]
+        fixed byte l_tls_modid[4];
+        [FieldOffset(616)]
+        fixed byte l_tls_dtor_count[4];
+        [FieldOffset(620)]
+        fixed byte l_relro_addr[4];
+        [FieldOffset(624)]
+        fixed byte l_relro_size[4];
+        [FieldOffset(628)]
+        fixed byte l_serial[8];
+    }
+
+}

--- a/MemoryModule/Linux/GlibcInterop/2_38/64/Natives.g.cs
+++ b/MemoryModule/Linux/GlibcInterop/2_38/64/Natives.g.cs
@@ -1,0 +1,208 @@
+// Native structure offsets for glibc, on x86 and x86_64.
+// Generated using GlibcOffsetGen. Do not modify.
+
+using System;
+using System.Runtime.InteropServices;
+namespace GlibcInterop
+{
+    [StructLayout(LayoutKind.Explicit, Size = 4328)]
+    unsafe partial struct rtld_global_2_38_64
+    {
+        [FieldOffset(0)]
+        fixed byte _dl_ns[2560];
+        [FieldOffset(2560)]
+        fixed byte _dl_nns[8];
+        [FieldOffset(2568)]
+        fixed byte _dl_load_lock[40];
+        [FieldOffset(2608)]
+        fixed byte _dl_load_write_lock[40];
+        [FieldOffset(2648)]
+        fixed byte _dl_load_tls_lock[40];
+        [FieldOffset(2688)]
+        fixed byte _dl_load_adds[8];
+        [FieldOffset(2696)]
+        fixed byte _dl_initfirst[8];
+        [FieldOffset(2704)]
+        fixed byte _dl_profile_map[8];
+        [FieldOffset(2712)]
+        fixed byte _dl_num_relocations[8];
+        [FieldOffset(2720)]
+        fixed byte _dl_num_cache_relocations[8];
+        [FieldOffset(2728)]
+        fixed byte _dl_all_dirs[8];
+        [FieldOffset(2736)]
+        fixed byte _dl_rtld_map[1184];
+        [FieldOffset(3920)]
+        fixed byte _dl_rtld_auditstate[256];
+        [FieldOffset(4176)]
+        fixed byte _dl_x86_feature_1[4];
+        [FieldOffset(4180)]
+        fixed byte _dl_x86_feature_control[4];
+        [FieldOffset(4184)]
+        fixed byte _dl_stack_flags[4];
+        [FieldOffset(4188)]
+        fixed byte _dl_tls_dtv_gaps[1];
+        [FieldOffset(4192)]
+        fixed byte _dl_tls_max_dtv_idx[8];
+        [FieldOffset(4200)]
+        fixed byte _dl_tls_dtv_slotinfo_list[8];
+        [FieldOffset(4208)]
+        fixed byte _dl_tls_static_nelem[8];
+        [FieldOffset(4216)]
+        fixed byte _dl_tls_static_used[8];
+        [FieldOffset(4224)]
+        fixed byte _dl_tls_static_optional[8];
+        [FieldOffset(4232)]
+        fixed byte _dl_initial_dtv[8];
+        [FieldOffset(4240)]
+        fixed byte _dl_tls_generation[8];
+        [FieldOffset(4248)]
+        fixed byte _dl_scope_free_list[8];
+        [FieldOffset(4256)]
+        fixed byte _dl_stack_used[16];
+        [FieldOffset(4272)]
+        fixed byte _dl_stack_user[16];
+        [FieldOffset(4288)]
+        fixed byte _dl_stack_cache[16];
+        [FieldOffset(4304)]
+        fixed byte _dl_stack_cache_actsize[8];
+        [FieldOffset(4312)]
+        fixed byte _dl_in_flight_stack[8];
+        [FieldOffset(4320)]
+        fixed byte _dl_stack_cache_lock[4];
+    }
+
+    [StructLayout(LayoutKind.Explicit, Size = 1184)]
+    unsafe partial struct link_map_2_38_64
+    {
+        [FieldOffset(0)]
+        fixed byte l_addr[8];
+        [FieldOffset(8)]
+        fixed byte l_name[8];
+        [FieldOffset(16)]
+        fixed byte l_ld[8];
+        [FieldOffset(24)]
+        fixed byte l_next[8];
+        [FieldOffset(32)]
+        fixed byte l_prev[8];
+        [FieldOffset(40)]
+        fixed byte l_real[8];
+        [FieldOffset(48)]
+        fixed byte l_ns[8];
+        [FieldOffset(56)]
+        fixed byte l_libname[8];
+        [FieldOffset(64)]
+        fixed byte l_info[640];
+        [FieldOffset(704)]
+        fixed byte l_phdr[8];
+        [FieldOffset(712)]
+        fixed byte l_entry[8];
+        [FieldOffset(720)]
+        fixed byte l_phnum[2];
+        [FieldOffset(722)]
+        fixed byte l_ldnum[2];
+        [FieldOffset(728)]
+        fixed byte l_searchlist[16];
+        [FieldOffset(744)]
+        fixed byte l_symbolic_searchlist[16];
+        [FieldOffset(760)]
+        fixed byte l_loader[8];
+        [FieldOffset(768)]
+        fixed byte l_versions[8];
+        [FieldOffset(776)]
+        fixed byte l_nversions[4];
+        [FieldOffset(780)]
+        fixed byte l_nbuckets[4];
+        [FieldOffset(784)]
+        fixed byte l_gnu_bitmask_idxbits[4];
+        [FieldOffset(788)]
+        fixed byte l_gnu_shift[4];
+        [FieldOffset(792)]
+        fixed byte l_gnu_bitmask[8];
+        [FieldOffset(800)]
+        fixed byte l_gnu_buckets[8];
+        [FieldOffset(800)]
+        fixed byte l_chain[8];
+        [FieldOffset(808)]
+        fixed byte l_gnu_chain_zero[8];
+        [FieldOffset(808)]
+        fixed byte l_buckets[8];
+        [FieldOffset(816)]
+        fixed byte l_direct_opencount[4];
+        [FieldOffset(823)]
+        fixed byte l_nodelete_active[1];
+        [FieldOffset(824)]
+        fixed byte l_nodelete_pending[1];
+        [FieldOffset(828)]
+        fixed byte l_x86_feature_1_and[4];
+        [FieldOffset(832)]
+        fixed byte l_x86_isa_1_needed[4];
+        [FieldOffset(836)]
+        fixed byte l_1_needed[4];
+        [FieldOffset(840)]
+        fixed byte l_rpath_dirs[16];
+        [FieldOffset(856)]
+        fixed byte l_reloc_result[8];
+        [FieldOffset(864)]
+        fixed byte l_versyms[8];
+        [FieldOffset(872)]
+        fixed byte l_origin[8];
+        [FieldOffset(880)]
+        fixed byte l_map_start[8];
+        [FieldOffset(888)]
+        fixed byte l_map_end[8];
+        [FieldOffset(896)]
+        fixed byte l_text_end[8];
+        [FieldOffset(904)]
+        fixed byte l_scope_mem[32];
+        [FieldOffset(936)]
+        fixed byte l_scope_max[8];
+        [FieldOffset(952)]
+        fixed byte l_local_scope[16];
+        [FieldOffset(968)]
+        fixed byte l_file_id[16];
+        [FieldOffset(984)]
+        fixed byte l_runpath_dirs[16];
+        [FieldOffset(1008)]
+        fixed byte l_reldeps[8];
+        [FieldOffset(1016)]
+        fixed byte l_reldepsmax[4];
+        [FieldOffset(1020)]
+        fixed byte l_used[4];
+        [FieldOffset(1024)]
+        fixed byte l_feature_1[4];
+        [FieldOffset(1028)]
+        fixed byte l_flags_1[4];
+        [FieldOffset(1032)]
+        fixed byte l_flags[4];
+        [FieldOffset(1036)]
+        fixed byte l_idx[4];
+        [FieldOffset(1040)]
+        fixed byte l_mach[24];
+        [FieldOffset(1064)]
+        fixed byte l_lookup_cache[32];
+        [FieldOffset(1096)]
+        fixed byte l_tls_initimage[8];
+        [FieldOffset(1104)]
+        fixed byte l_tls_initimage_size[8];
+        [FieldOffset(1112)]
+        fixed byte l_tls_blocksize[8];
+        [FieldOffset(1120)]
+        fixed byte l_tls_align[8];
+        [FieldOffset(1128)]
+        fixed byte l_tls_firstbyte_offset[8];
+        [FieldOffset(1136)]
+        fixed byte l_tls_offset[8];
+        [FieldOffset(1144)]
+        fixed byte l_tls_modid[8];
+        [FieldOffset(1152)]
+        fixed byte l_tls_dtor_count[8];
+        [FieldOffset(1160)]
+        fixed byte l_relro_addr[8];
+        [FieldOffset(1168)]
+        fixed byte l_relro_size[8];
+        [FieldOffset(1176)]
+        fixed byte l_serial[8];
+    }
+
+}

--- a/MemoryModule/Linux/GlibcInterop/GlibcEnvironment.cs
+++ b/MemoryModule/Linux/GlibcInterop/GlibcEnvironment.cs
@@ -18,13 +18,13 @@ namespace GlibcInterop
 
         public static readonly Version Version;
         public static readonly Version FirstAvailableVersion = new Version(2, 21);
-        public static readonly Version LatestAvailableVersion = new Version(2, 34);
+        public static readonly Version LatestAvailableVersion = new Version(2, 38);
 
         static GlibcEnvironment()
         {
             try
             {
-                // We cannot use the MarshalAsAttribute here, as 
+                // We cannot use the MarshalAsAttribute here, as
                 // glibc returns a string in read only memory, while
                 // .NET tries to free that memory after marshalling.
                 var libcVerString = Marshal.PtrToStringAnsi(gnu_get_libc_version());


### PR DESCRIPTION
There are still problems with the `rtld_global` stuff, but this hack should have been deprecated in favor of the abstractions branch anyway.